### PR TITLE
Redirect to intended admin page after login

### DIFF
--- a/app/Interactions/UserLogin.php
+++ b/app/Interactions/UserLogin.php
@@ -92,7 +92,7 @@ class UserLogin implements Contract
      */
     public function redirectToHome(array $errors = [])
     {
-        return redirect()->route('home')->withErrors(['global' => $errors]);
+        return redirect()->intended(route('home'))->withErrors(['global' => $errors]);
     }
 
     /**


### PR DESCRIPTION
Test case:
- Create a new route with auth middleware in `routes.php`
- Visit that URL in guest mode
- Login or register
- After login or register, it should be redirected to the new route URL, but currently it's not the case